### PR TITLE
chore: drop Bun, switch to Node + Nitro

### DIFF
--- a/.changeset/drop-bun-add-nitro.md
+++ b/.changeset/drop-bun-add-nitro.md
@@ -1,4 +1,5 @@
 ---
+"xiaofeng-blog": patch
 ---
 
 Switch the runtime from Bun to Node and wire the `nitro()` plugin into Vite

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,10 +2,7 @@
   "mcpServers": {
     "vite-plus": {
       "command": "npx",
-      "args": [
-        "vp",
-        "mcp"
-      ]
+      "args": ["vp", "mcp"]
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,1 @@
 My blog: https://www.xiaofengxie.dev/
-

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,8 @@ import babel from "@rolldown/plugin-babel";
 import tailwindcss from "@tailwindcss/vite";
 import { nitro } from "nitro/vite";
 
+const isTest = !!process.env.VITEST;
+
 export default defineConfig({
   fmt: {
     ignorePatterns: ["src/routeTree.gen.ts", ".output/**", "dist/**"],
@@ -25,13 +27,13 @@ export default defineConfig({
   },
   plugins: [
     tailwindcss(),
-    tanstackStart({ srcDirectory: "src" }),
+    ...(isTest ? [] : [tanstackStart({ srcDirectory: "src" })]),
     viteReact(),
     babel({
       parserOpts: { plugins: ["typescript", "jsx"] },
       presets: [reactCompilerPreset()],
     }),
-    nitro(),
+    ...(isTest ? [] : [nitro()]),
   ],
   test: {
     environment: "jsdom",


### PR DESCRIPTION
## Summary
- Switch runtime from Bun to Node and wire Nitro for TanStack Start (see c6f42dc)
- Guard `tanstackStart` and `nitro` Vite plugins behind a `VITEST` check so tests can run without the full server stack
- Minor formatting cleanup in `.claude/settings.json` and `README.md`

## Test plan
- [ ] `vp install`
- [ ] `vp check`
- [ ] `vp test`
- [ ] `vp build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)