### PR TITLE
Revert devEngines package manager declaration (unbreaks Fly deploy)

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,14 +63,8 @@
     "vite": "npm:@voidzero-dev/vite-plus-core@0.2.8",
     "vitest": "4.1.10"
   },
-  "devEngines": {
-    "packageManager": {
-      "name": "npm",
-      "version": "12.0.2",
-      "onFail": "download"
-    }
-  },
   "engines": {
     "node": ">=22.12.0"
-  }
+  },
+  "packageManager": "npm@11.12.1"
 }


### PR DESCRIPTION
Reverts `da9f2ed` from #178. **Fixes a broken production deploy.**

## What happened

The `Deploy app` job on `main` failed after #178 merged:

```
npm error code EBADDEVENGINES
npm error EBADDEVENGINES Invalid semver version "12.0.2" does not match "11.17.0" for "packageManager"
npm error EBADDEVENGINES   current:  { name: 'npm', version: '11.17.0' }
npm error EBADDEVENGINES   required: { name: 'npm', version: '12.0.2', onFail: 'download' }
```

`Dockerfile:26` runs `npm ci` directly with the base image's npm and never goes through `vp`. Two things follow:

- **npm enforces `devEngines`** and hard-fails on a mismatch. `onFail: "download"` is honored by `vp`, not by npm itself.
- The legacy `packageManager` field is advisory as far as npm is concerned, which is why it never blocked `npm ci`.

No outage — the build failed before the deploy step, so Fly kept serving the previous version.

## Why CI didn't catch it

`Test and Build` uses `vp install`, which reads the manifest and resolves the declared npm. Only the Docker build bypasses `vp`. Green CI on #178 was real but did not cover the deploy path. I verified `setup-vp` handled `devEngines` and did not check the Dockerfile — that was the gap.

## Verification

`package.json` here is byte-identical to `dd64c4b`, the last commit whose tree both passed CI and matches the configuration that has been deploying successfully. npm cannot emit `EBADDEVENGINES` when the field is absent.

Local: `vp check` (52 files, 0 errors), `vp test run --coverage` (17/17), `vp build` all pass.

I attempted to reproduce the Docker failure locally and **could not** — `npm` on a Vite+ machine is a symlink to `vp`, so it resolves npm from the manifest and satisfies `devEngines` rather than failing. Any future attempt to validate this path needs a real container, not a local `npm ci`.

## If devEngines is wanted later

`Dockerfile:26` has to install through `vp` as well, rather than calling `npm ci` with the image's npm. Worth pairing with a Dockerfile change in a single PR, and confirming against an actual container build before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxrTxoddE3fGdpD5FSw8AM